### PR TITLE
Testimonial video auto height to prevent cropping

### DIFF
--- a/src/stylesheets/pages/_landing.scss
+++ b/src/stylesheets/pages/_landing.scss
@@ -55,37 +55,43 @@
 #testimonial-video {
   text-align: center;
   width: 100vw;
-  height: 100vh;
+  // height: 100vh;
   display: block;
+
   .vid-container{
+    min-height: 450px;
     display: flex;
     align-items: center;
     justify-content: center;
+    position: relative;
 
     &,
     video {
       width: 100vw;
-      height: 100vh;
-      max-height: 100vh;
-      overflow: hidden;
+      min-height: 500px;
+      // height: 100vh;
+      // max-height: 100vh;
+      // overflow: hidden;
       background: $dark-grey;
       object-fit: cover;
-      position: absolute;
+      // position: absolute;
 
       .video-overlay {
         background-color: rgba(66, 70, 80, 0.8);
-        width: 100vw;
-        height: 100vh;
         position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
       }
-      
+
     .testimonial-title {
       color: $bright-gold;
       font-size: 1.8rem;
       line-height: 2rem;
       margin-bottom: 1rem;
     }
-      
+
     @-webkit-keyframes fadeOut {
       0% { opacity: 1;}
       99% { opacity: 0.01;width: 100%; height: 100%;}
@@ -244,7 +250,7 @@ section.landing-about-us {
 
       .dot {
         margin: 0 3px 3px 0;
-        
+
       }
 
       h3 {
@@ -320,7 +326,7 @@ section.landing-about-us {
   }
   .landing-blog-title-container {
     width: 100%;
-    
+
   }
 }
 


### PR DESCRIPTION
Carlyn requested so that the logo doesn't get cropped at reduced width.
the only way is the make the video to have auto height based on current width to keep the current aspect ratio.
But I kept min-height at 500px so that the golden box doesn't overflow.